### PR TITLE
Fix missing variable declaration in leaf.md

### DIFF
--- a/guides/leaf.md
+++ b/guides/leaf.md
@@ -126,7 +126,7 @@ function veins() {
 
     // try playing with the `0.1` term
     // interpolate returns a point and we take `[1]` to get the y value
-    y = edge.interpolate(t + 0.1)[1]
+    const y = edge.interpolate(t + 0.1)[1]
 
     const line = createTurtle([x0, y0])
 


### PR DESCRIPTION
`y` is not declared previously and produces an error at runtime

![image](https://github.com/hackclub/blot/assets/44947946/1b28d6f4-0272-44a3-bdf8-5bd3a7bcdcec)
