### PR TITLE
Add a warning on Math.random()

### DIFF
--- a/astro/src/lib/run.ts
+++ b/astro/src/lib/run.ts
@@ -38,6 +38,18 @@ const hConsole = {
   warn: (...args: [any, ...any[]]) => baseLogger('warn', ...args)
 }
 
+let DETECTED_RANDOM_USAGE = false
+const patchedRandom = (() => {
+  if (!DETECTED_RANDOM_USAGE) {
+    hConsole.warn(`Math.random() called! This could cause issues if done unintentionally.
+    https://github.com/hackclub/blot/issues/161`)
+    DETECTED_RANDOM_USAGE = true
+  }
+  return Math.__proto__.unpatchedRandom()
+})
+Math.__proto__.unpatchedRandom = Math.random
+Math.random = patchedRandom
+
 let intervals: number[] = []
 let timeouts: number[] = []
 const patchedInterval = (


### PR DESCRIPTION
Fixes https://github.com/hackclub/blot/issues/161

```js
// when you run the following...
console.log(Math.random())
console.log(Math.random())
console.log(Math.random())
console.log(Math.random())
```

```
WARN> Math.random() called! This could cause issues if done unintentionally. https://github.com/hackclub/blot/issues/161
> 0.6913689623313306
> 0.8114130283005876
> 0.2853826537241573
> 0.217250787267246
```
