### PR TITLE
Don't stop execution if error position function fails

### DIFF
--- a/astro/src/lib/run.ts
+++ b/astro/src/lib/run.ts
@@ -190,13 +190,20 @@ async function runCodeInner(str, globalScope) {
 }
 
 function getPosFromErr(err) {
-  const match = err.stack.match(/<anonymous>:(\d+):(\d+)/)
+  try {
+    const match = err.stack.match(/<anonymous>:(\d+):(\d+)/)
 
-  const pos = { line: Number(match[1]) - 2, column: Number(match[2]) }
+    const pos = { line: Number(match[1]) - 2, column: Number(match[2]) }
 
-  // to account for "use strict\n"
-  pos.line -= 1
-  pos.column -= 1
+    // to account for "use strict\n"
+    pos.line -= 1
+    pos.column -= 1
 
-  return pos
+    return pos
+  } catch (e) {
+    // An error in the error handler?!
+    // that's embarassing.
+    console.log('Unable to catch error position:', e)
+    return { line: 1, column: 1 }
+  }
 }


### PR DESCRIPTION
This is to address https://github.com/hackclub/blot/issues/214. As mentioned in this comment https://github.com/hackclub/blot/issues/214#issuecomment-1862162643, this PR doesn't fully fix #214. Rather, it adds a sane default to not crash the page's execution if `getPosFromError` fails to find where an error is.