### PR TITLE
a few small bugfixes

### DIFF
--- a/backend/extractFrontmatter.js
+++ b/backend/extractFrontmatter.js
@@ -1,6 +1,7 @@
 export function extractFrontmatter(markdown) {
   // Regular expression to match frontmatter: starts with ---, ends with ---, and captures content in-between
-  const frontmatterRegex = /^---\n([\s\S]+?)\n---/;
+  // with optional \r for Windows line endings
+  const frontmatterRegex = /^---\r?\n([\s\S]+?)\r?\n---/;
   const match = markdown.match(frontmatterRegex);
 
   if (!match) {

--- a/src/defaultProgram.js
+++ b/src/defaultProgram.js
@@ -66,5 +66,5 @@ const cc = bounds(finalPolylines).cc;
 translate(finalPolylines, [width / 2, height / 2], cc);
 
 // draw it
-draw(finalPolylines);
+drawLines(finalPolylines);
 `.trim()

--- a/src/drawingToolkit/Turtle.js
+++ b/src/drawingToolkit/Turtle.js
@@ -47,6 +47,7 @@ export class Turtle {
     const lastPath = this.path.at(-1);
     if (lastPath.length === 1) {
       lastPath[0] = [x, y];
+      this.position = [x, y];
       return this;
     }
 


### PR DESCRIPTION
- Allow CRLFs in the frontmatter of guides via a regex tweak in extractFrontmatter.js (yes, i was on Windows, why do you ask?)
- Make the default program use the drawLines function instead of the nonexistent draw function
- Fix a bug in Turtle.forward that made it break when used after a pen-up jump