### PR TITLE
Remove tolerance on pointInPolylines to fix boolean line-type flipping

### DIFF
--- a/src/drawingToolkit/pointInPolylines.js
+++ b/src/drawingToolkit/pointInPolylines.js
@@ -22,8 +22,9 @@ function pointInPolyline(point, polyline, ops = {}) {
     let xj = polyline[j][0], yj = polyline[j][1];
 
     // if on edge
-    const distanceToSegment = pDistance(point, [xj, yj], [xi, yi]);
-    if (distanceToSegment < 1e-4) return edge;
+    // Tentatively removed since it causes bugs and doesn't seem necessary
+    // const distanceToSegment = pDistance(point, [xj, yj], [xi, yi]);
+    // if (distanceToSegment < 1e-4) return edge;
 
     if (yj <= y) {
       if (yi > y) {


### PR DESCRIPTION
As described in issue #420, checking if a point is within a very small epsilon of of a polyline's border and counting it as outside as so leads to segments with points very close to the border registering as the wrong type (inside gets registered as outside and vice versa) in cutcover ([test case](https://blot.hackclub.com/editor)). Deleting it doesn't seem to have any adverse effects and fixes it.