### PR TITLE
Bug fix - fix SVG imports flipped vertically issue

### DIFF
--- a/src/drawingToolkit/toolkit.js
+++ b/src/drawingToolkit/toolkit.js
@@ -126,6 +126,23 @@ export const toolkit = {
       const svg = doc.querySelector('svg');
       const polylines = flattenSVG(svg, { maxError: 0.001 }).map(pl => pl.points);
 
+      let maxYVal = 0;
+      polylines.forEach((obj) => {
+        obj.forEach((coord) => {
+          if (coord[1] > maxYVal) {
+            maxYVal = coord[1];
+          }
+
+          coord[1] = -coord[1];
+        })
+      })
+
+      polylines.forEach((obj) => {
+        obj.forEach((coord) => {
+          coord[1] = coord[1] + maxYVal;
+        })
+      })
+
       return polylines;
     } catch (err) {
       throw new Error("SVGs can not be parsed in web workers.");


### PR DESCRIPTION
This fixes the bug where SVG imports are flipped vertically. This issue arises due to the different coordinate systems between the Blot and SVG standards.

Before:
![before](https://github.com/user-attachments/assets/309c6500-f8c9-4ffb-8ab5-a2b4f694f7b5)


After:
![after](https://github.com/user-attachments/assets/8aa16a59-37f1-4726-a13b-ea05399bec0d)
