### PR TITLE
Add plagiarism checker

### DIFF
--- a/.github/scripts/extract_percentages.py
+++ b/.github/scripts/extract_percentages.py
@@ -1,0 +1,63 @@
+from bs4 import BeautifulSoup
+import os
+import sys
+
+def extract_similarity_percentage(html_file, type):
+    try:
+        with open(html_file, 'r', encoding='utf-8') as file:
+            soup = BeautifulSoup(file, 'html.parser')
+            file_name_tag = soup.select_one(f"#{type}left > div > h4")
+            if file_name_tag:
+                percentage_text = file_name_tag.find("span", class_="text-secondary small").text.strip("()%")
+                return int(percentage_text)
+            else:
+                return None
+    except Exception as e:
+        print(f"Error processing file {html_file}: {e}")
+        return None
+
+def process_html_files(directory, threshold=50, noise_threshold=20):
+    print("Processing HTML files for plagiarism results...")
+    high_plagiarism_detected = False
+    high_plagiarism_files = []
+    for filename in os.listdir(directory):
+        if filename.endswith(".html"):
+            file_path = os.path.join(directory, filename)
+            percentage = extract_similarity_percentage(file_path,"structure")
+            percentage_text = extract_similarity_percentage(file_path,"text")
+            if percentage is not None and percentage >= threshold:
+                print(f"High plagiarism detected - {filename.replace('.html', '')}: {percentage}%, {percentage_text}%")
+                high_plagiarism_files.append(f"{filename.replace('.html', '')}: \n- Structure: {percentage}% \n- Text: {percentage_text}%")
+                high_plagiarism_detected = True
+            elif percentage is not None and percentage < noise_threshold: # Avoid huge action artifacts
+                print(f"Removing plagiarism report with {filename.replace('.html', '')}: {percentage}%,{percentage_text}% score as noise")
+                os.remove(file_path)
+    return high_plagiarism_detected, high_plagiarism_files
+
+def write_to_markdown(file_path, lines):
+    with open(file_path, 'w') as md_file:
+        for line in lines:
+            md_file.write(line + '\n')
+    print(f"Markdown file written to {file_path}")
+
+def main():
+    if len(sys.argv) != 2:
+        print("Incorrect number of arguments provided.")
+        print("Usage: python extract_percentages.py <saved_dir_path>")
+        sys.exit(1)
+
+    saved_dir_path = sys.argv[1]
+    high_plagiarism_detected, high_plagiarism_files = process_html_files(saved_dir_path)
+
+    markdown_lines = ["# Plagiarism Report"]
+    if high_plagiarism_detected:
+        print("High plagiarism percentages detected.")
+        markdown_lines.append("## Art overlap report:")
+        markdown_lines.extend(high_plagiarism_files)
+        write_to_markdown("plagiarism-report.md", markdown_lines)
+        sys.exit(1)
+    else:
+        print("No high plagiarism percentages detected.")
+    print("Plagiarism report generation completed.")
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/plagiarism_check.py
+++ b/.github/scripts/plagiarism_check.py
@@ -1,0 +1,82 @@
+import sys
+import subprocess
+import os
+import glob
+import shutil
+
+def run_compare50(single_file, directory, output_dir, saved_dir_base):
+    try:
+        if not os.path.exists(saved_dir_base):
+            os.makedirs(saved_dir_base)
+            print("Created base directory for saved files.")
+
+        all_js_files = glob.glob(os.path.join(directory, "**/index.js"))
+        total_files = len(all_js_files)
+        current_file_number = 0
+
+        for file in all_js_files:
+            current_file_number += 1
+            if os.path.abspath(file) == os.path.abspath(single_file):
+                print(f"Skipping comparison for the same file: {file}")
+                continue
+
+            print(f"Processing file {current_file_number} of {total_files}: {file}")
+            if os.path.exists(output_dir):
+                shutil.rmtree(output_dir)
+                print(f"Cleaned existing output directory: {output_dir}")
+            
+            command = [
+                "compare50",
+                f'"{single_file}"',
+                f'"{file}"',
+                "--output", f'"{output_dir}"',
+                "--max-file-size", str(1024 * 1024 * 100),
+                "--passes", "structure text"
+            ]
+
+            command_str = ' '.join(command)
+            print(f"Running command: {command_str}")
+            subprocess.run(command_str, shell=True, check=True)
+            print("Compare50 command executed successfully.")
+
+            match_file = os.path.join(output_dir, "match_1.html")
+
+            if os.path.exists(match_file):
+                new_filename = os.path.basename(os.path.normpath(os.path.dirname(file))) + '.html'
+                saved_file_path = os.path.join(saved_dir_base, new_filename)
+                print(f"Match found. Moving {match_file} to {saved_file_path}")
+                shutil.move(match_file, saved_file_path)
+            else:
+                print(f"No match found for file: {file}")
+
+    except subprocess.CalledProcessError as e:
+        print(f"Error in running Compare50: {e}")
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+def main():
+    if len(sys.argv) != 5:
+        print("Incorrect number of arguments provided.")
+        print("Usage: python plagiarism_check.py <single_file> <directory> <output_dir> <saved_dir_base>")
+        sys.exit(1)
+
+    single_file = sys.argv[1]
+    directory = sys.argv[2]
+    output_dir = sys.argv[3]
+    saved_dir_base = sys.argv[4]
+
+    print(f"Starting plagiarism check with the following arguments:")
+    print(f"Single file: {single_file}")
+    print(f"Directory: {directory}")
+    print(f"Output directory: {output_dir}")
+    print(f"Saved directory base: {saved_dir_base}")
+
+    # print(f"Listing all JavaScript files in directory '{directory}':")
+    # for f in glob.glob(os.path.join(directory, "**/index.js")):
+    #     print(f)
+
+    run_compare50(single_file, directory, output_dir, saved_dir_base)
+    print("Plagiarism check completed.")
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/check_plagiarism.yml
+++ b/.github/workflows/check_plagiarism.yml
@@ -1,0 +1,88 @@
+name: Plagiarism Checker
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+on:
+  pull_request:
+    paths:
+      - "art/**/*.js"
+
+jobs:
+  plagiarism-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install Compare50 && beautifulsoup4
+        run: pip install compare50 beautifulsoup4
+
+      - name: Get list of changed files
+        id: changed-files
+        run: |
+          echo "Pull Request Base SHA: ${{ github.event.pull_request.base.sha }}"
+          echo "Pull Request Head SHA: ${{ github.event.pull_request.head.sha }}"
+          git diff --name-only --diff-filter=AM --find-renames --find-copies ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | grep 'art/.*\.js$' | xargs
+          js_files=$(git diff --name-only --diff-filter=AM --find-renames --find-copies ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | grep 'art/.*\.js$' | xargs)
+          echo "FILES=$js_files" >> $GITHUB_ENV
+
+      - name: Run Plagiarism Detection Script
+        if: env.FILES != ''
+        run: python .github/scripts/plagiarism_check.py "${{ env.FILES }}" art output_dir saved_dir
+
+      - name: Extract and Display Similarity Percentages
+        run: python .github/scripts/extract_percentages.py saved_dir/
+        id: extract-percentages
+
+      - name: Upload Compare50 Results as Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: compare50-results
+          path: saved_dir/
+
+      - name: Save PR number to file
+        if: always()
+        run: echo ${{ github.event.pull_request.number }} > pr_number.txt
+
+      - name: Upload Plagiarism Report as Artifact
+        if: always() && steps.extract-percentages.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: plagiarism-report
+          path: plagiarism-report.md
+
+      - name: Check for High Plagiarism Percentages
+        if: always() && steps.extract-percentages.outcome == 'failure'
+        run: echo "Plagiarism percentage over threshold detected."
+
+      - name: Post Markdown as Comment
+        if: always() && steps.extract-percentages.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            console.log("Reading pr number...")
+            const prNumber = fs.readFileSync('./pr_number.txt', 'utf8').trim();
+            console.log("Reading report...")
+            const markdownContent = fs.readFileSync('./plagiarism-report.md', 'utf8');
+            console.log("Posting the Markdown content as a comment...");
+            const commentResponse = await github.rest.issues.createComment({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: markdownContent
+            });
+            console.log(`Comment posted successfully: ${commentResponse.data.html_url}`);


### PR DESCRIPTION
This PR adds a plagiarism checker workflow (fixes #681). It runs for every art PR and compares the added art code to all other submissions. The workflow is a modified version of the sprig plagiarism checker ( differences: structure pass, folder structure of submissions and other minor things )

## How it works
- It uses compare50 and the structure and text passes. The structure pass ignores whitespace, comments and variable names while the text pass ignores only whitespace and comments. 
- If the structure score is > 50% it is flagged as plagiarism and a comment is made by github-actions giving the structure and texts passes scores.
- An action artifact named `compare50-results` is generated with an html file detailing the results for every score >10% match ( < 10% matches are not useful as a simple nested for loop triggers a small match )

**You can see a demo in the [fork pull requests](https://github.com/Dimitris-Toulis/blot/pulls)**
The copied art fails the check and the comment is triggered while the original one passes the check

[Relevant slack link](https://hackclub.slack.com/archives/C04GCH8A91D/p1725457382221759?thread_ts=1725457382.221759&cid=C04GCH8A91D)